### PR TITLE
Modify leak tests to account for COWable folded CONSTs from Perl v5.41.x

### DIFF
--- a/t/03-non-tolerate.t
+++ b/t/03-non-tolerate.t
@@ -7,7 +7,8 @@ use Test::Warnings;
 
 # request large array, that should trigger additional memory alloactions
 ok !noleaks(
-    code          => sub { my $x = "a" x (10_000_000); },
+    code          => sub { my $x = "a" x (10_000_000);
+                           $x .= localtime},
     track_memory  => 1,
     track_fds     => 0,
     passes        => 5,

--- a/t/04-no-warm-up.t
+++ b/t/04-no-warm-up.t
@@ -7,7 +7,7 @@ use Test::Warnings;
 
 my $cache2;
 ok !noleaks(
-    code          => sub { $cache2 = "a" x (10_000_000) unless $cache2; },
+    code          => sub { $cache2 = ("a" x 10_000_000).localtime unless $cache2; },
     track_memory  => 1,
     track_fds     => 1,
     passes        => 5,


### PR DESCRIPTION
Prior to the Perl 5.41 development cycle, running code like `$x = "a" x (10_000_000);` many times in a loop - and keeping an active reference to the resulting scalars - would cause perl to allocate many separate string buffers, each containing 10_000_000 "a"s, being active.

In the Perl 5.41 development cycle, constant folded strings like `"a" x (10_000_000)` now get the `IsCOW` flag set. Consequently, running `$x = "a" x (10_000_000);` many times now gives multiple scalars all pointing to the _same_ string buffer.

The upshot of this is that if you want to deliberately simulate leakage of a buffer, as per some of this module's tests, you must now perform a string permutation, causing a full copy of the buffer to be made. Not doing so means that some tests fail on recent development releases (and will do so on the next stable release). For example:
* http://fast2-matrix.cpantesters.org/?dist=Test-NoLeaks+0.06
* https://www.cpantesters.org/cpan/report/0642ceee-95aa-11ef-9355-e60340f7171c

The attached patches are one way to do this. `localtime` is appended to the relevant constants, forcing the unique copy to be made. (These changes are backwards compatible with the previous constant behaviour.)

Please let me know if you are able to do a release incorporating these patches or otherwise making the tests compatible with IsCOW folded constants. If you have any queries, questions or concerns, please also let me know.